### PR TITLE
ci: restrict permissions of tokens

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -1,5 +1,8 @@
 name: Build SKIA
 on: workflow_dispatch
+permissions:
+  contents: read    # Read repository contents
+  actions: write    # Publish artifacts
 jobs:
   build:
     runs-on: macos-latest-xlarge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read    # Read repository contents
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR reduces the required permissions for building skia & the continuous integration workflow.