### PR TITLE
fix: pure tsc builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build
+        run: yarn build
+
       - name: Test
         run: yarn test
 

--- a/packages/skia/.eslintrc
+++ b/packages/skia/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "react-native-wcandillon",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.lint.json"
   },
   "rules": {
     "prefer-destructuring": [

--- a/packages/skia/index.ts
+++ b/packages/skia/index.ts
@@ -1,1 +1,0 @@
-export * from "./src";

--- a/packages/skia/jestSetup.mjs
+++ b/packages/skia/jestSetup.mjs
@@ -1,12 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { jest } from "@jest/globals";
 import CanvasKitInit from "canvaskit-wasm/bin/full/canvaskit";
-import { Mock } from "@exodus/react-native-skia/lib/module/mock";
+import { Mock } from "@exodus/react-native-skia/lib/mock";
 
 global.CanvasKit = await CanvasKitInit({});
 
 jest.mock("@exodus/react-native-skia", () => {
-  jest.mock("@exodus/react-native-skia/lib/commonjs/Platform", () => {
+  jest.mock("@exodus/react-native-skia/lib/Platform", () => {
     const Noop = () => undefined;
     return {
       OS: "web",
@@ -18,7 +18,7 @@ jest.mock("@exodus/react-native-skia", () => {
       View: Noop,
     };
   });
-  jest.mock("@exodus/react-native-skia/lib/commonjs/skia/core/Font", () => {
+  jest.mock("@exodus/react-native-skia/lib/skia/core/Font", () => {
     return {
       useFont: () => null,
       matchFont: () => null,

--- a/packages/skia/package.json
+++ b/packages/skia/package.json
@@ -10,10 +10,10 @@
   "title": "React Native Skia",
   "version": "0.0.0",
   "description": "High-performance React Native Graphics using Skia",
-  "main": "lib/module/index.js",
-  "react-native": "src/index.ts",
-  "module": "lib/module/index.js",
-  "types": "lib/typescript/index.d.ts",
+  "main": "lib/index.js",
+  "react-native": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "src/**",
     "lib/**",
@@ -37,11 +37,11 @@
   ],
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx  --max-warnings 0 --cache --fix",
-    "tsc": "tsc --noEmit",
+    "tsc": "tsc",
     "test": "jest",
     "e2e": "E2E=true yarn test -i e2e",
     "release": "semantic-release",
-    "build": "bob build && merge-dirs lib/typescript/src lib/commonjs && merge-dirs lib/typescript/src lib/module",
+    "build": "yarn tsc",
     "clean-skia": "yarn rimraf ./libs && yarn rimraf ../../externals/skia/out",
     "build-skia": "ts-node ./scripts/build-skia.ts",
     "copy-skia-headers": "ts-node ./scripts/copy-skia-headers.ts",
@@ -135,24 +135,5 @@
     "android": {
       "javaPackageName": "com.shopify.reactnative.skia"
     }
-  },
-  "react-native-builder-bob": {
-    "source": "src",
-    "output": "lib",
-    "targets": [
-      "commonjs",
-      [
-        "module",
-        {
-          "configFile": "./.babelrc"
-        }
-      ],
-      [
-        "typescript",
-        {
-          "project": "tsconfig.build.json"
-        }
-      ]
-    ]
   }
 }

--- a/packages/skia/package.json
+++ b/packages/skia/package.json
@@ -11,7 +11,7 @@
   "version": "0.0.0",
   "description": "High-performance React Native Graphics using Skia",
   "main": "lib/index.js",
-  "react-native": "lib/index.js",
+  "react-native": "src/index.ts",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/packages/skia/tsconfig.json
+++ b/packages/skia/tsconfig.json
@@ -5,7 +5,9 @@
       "dom",
       "es2019"
     ],
-    "noEmit": true,
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "lib",
     "allowJs": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
@@ -29,6 +31,7 @@
     "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
   },
+  "include": ["src"],
   "exclude": [
     "node_modules",
     "babel.config.js",

--- a/packages/skia/tsconfig.lint.json
+++ b/packages/skia/tsconfig.lint.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "es2019"
+    ],
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "lib",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "jsx": "react-native",
+    "strict": true,
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+    "noUncheckedIndexedAccess": false, /* Include 'undefined' in index signature results */
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true, /* Enable strict null checks. */
+    "strictFunctionTypes": true, /* Enable strict checking of function types. */
+    "strictBindCallApply": true, /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictPropertyInitialization": true, /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
+  },
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js",
+    "lib"
+  ]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,9 @@
         "cache": false
       },
       "lint": {},
-      "tsc": {},
+      "tsc": {
+        "dependsOn": ["^tsc"]
+      },
       "test": {},
       "build": {}
     }


### PR DESCRIPTION
Improve auditability by killing commonjs/module/typescript seperation & babel transpiling.