### PR TITLE
feat: ios p3 colors

### DIFF
--- a/packages/skia/apple/MetalContext.h
+++ b/packages/skia/apple/MetalContext.h
@@ -3,6 +3,7 @@
 #include "MetalWindowContext.h"
 #include "SkiaCVPixelBufferUtils.h"
 
+#include "include/core/SkColorSpace.h"
 #include "include/core/SkSurface.h"
 
 #import <include/gpu/ganesh/GrBackendSurface.h>
@@ -81,7 +82,7 @@ public:
     // Create a SkSurface from the GrBackendTexture
     auto surface = SkSurfaces::WrapBackendTexture(
         _directContext.get(), backendTexture, kTopLeft_GrSurfaceOrigin, 0,
-        kBGRA_8888_SkColorType, nullptr, nullptr,
+        kBGRA_8888_SkColorType, _wideColorSpace, nullptr,
         [](void *addr) { delete (OffscreenRenderContext *)addr; }, ctx);
 
     return surface;
@@ -124,6 +125,7 @@ public:
 private:
   id<MTLCommandQueue> _commandQueue = nullptr;
   sk_sp<GrDirectContext> _directContext = nullptr;
+  sk_sp<SkColorSpace> _wideColorSpace = nullptr;
 
   MetalContext();
 };

--- a/packages/skia/apple/MetalContext.mm
+++ b/packages/skia/apple/MetalContext.mm
@@ -31,4 +31,13 @@ MetalContext::MetalContext() {
   if (_directContext == nullptr) {
     RNSkia::RNSkLogger::logToConsole("Couldn't create a Skia Metal Context");
   }
+
+#if !TARGET_OS_OSX
+  if (@available(iOS 10.0, *)) {
+    if ([UIScreen mainScreen].traitCollection.displayGamut == UIDisplayGamutP3) {
+      _wideColorSpace = SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB,
+                                               SkNamedGamut::kDisplayP3);
+    }
+  }
+#endif
 }

--- a/packages/skia/apple/MetalWindowContext.h
+++ b/packages/skia/apple/MetalWindowContext.h
@@ -3,6 +3,7 @@
 #import <MetalKit/MetalKit.h>
 
 #include "WindowContext.h"
+#include "include/core/SkColorSpace.h"
 
 class SkiaMetalContext;
 
@@ -31,6 +32,7 @@ private:
   GrDirectContext *_directContext;
   id<MTLCommandQueue> _commandQueue;
   sk_sp<SkSurface> _skSurface = nullptr;
+  sk_sp<SkColorSpace> _colorSpace = nullptr;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
   CAMetalLayer *_layer;

--- a/packages/skia/apple/MetalWindowContext.mm
+++ b/packages/skia/apple/MetalWindowContext.mm
@@ -3,6 +3,8 @@
 #include "MetalContext.h"
 #include "RNSkLog.h"
 
+#include "include/core/SkColorSpace.h"
+
 MetalWindowContext::MetalWindowContext(GrDirectContext *directContext,
                                        id<MTLDevice> device,
                                        id<MTLCommandQueue> commandQueue,
@@ -31,6 +33,8 @@ MetalWindowContext::MetalWindowContext(GrDirectContext *directContext,
     CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3);
     _layer.colorspace = colorSpace;
     CGColorSpaceRelease(colorSpace);
+    _colorSpace = SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB,
+                                         SkNamedGamut::kDisplayP3);
   }
 }
 
@@ -56,7 +60,7 @@ sk_sp<SkSurface> MetalWindowContext::getSurface() {
 
   _skSurface = SkSurfaces::WrapBackendRenderTarget(
       _directContext, backendRT, kTopLeft_GrSurfaceOrigin,
-      kBGRA_8888_SkColorType, nullptr, nullptr);
+      kBGRA_8888_SkColorType, _colorSpace, nullptr);
 
   return _skSurface;
 }


### PR DESCRIPTION
  - Fix desaturated/faded colors when rendering P3 content (e.g. view snapshots) through Skia Canvas on P3-capable iOS devices
  - The CAMetalLayer was already configured with Display P3 color space, but the SkSurface wrapping it passed nullptr (sRGB) to Skia — causing a color space mismatch
  - Pass SkColorSpace::MakeRGB(kSRGB, kDisplayP3) to both WrapBackendRenderTarget (Canvas surface) and WrapBackendTexture (offscreen surfaces) on P3 devices

  What was wrong

  MetalWindowContext.mm set _layer.colorspace = kCGColorSpaceDisplayP3 on the Metal layer, but then created the Skia surface with:

```objc
  SkSurfaces::WrapBackendRenderTarget(
      ..., kBGRA_8888_SkColorType, nullptr, nullptr);
  //                                ^^^^^^^ Skia treats this as sRGB
```

  So Skia rendered all colors assuming sRGB, but the Metal layer interpreted the framebuffer as P3 — resulting in washed-out colors for any P3 content.


  Test plan

  - On a P3-capable iPhone, render view snapshots (via makeImageFromView) through a Skia Canvas
  - Compare colors before/after — previously desaturated P3 colors should now match the original views